### PR TITLE
banner: support for reading and writing UTF-16 banner titles

### DIFF
--- a/source/banner.cpp
+++ b/source/banner.cpp
@@ -48,6 +48,30 @@ unsigned short CalcBannerCRC(Banner &banner, unsigned short slot)
 	}
 }
 
+int GetBannerLanguageCount(unsigned short version)
+{
+	switch (version)
+	{
+		default:
+		case 0x0001: return 6;
+		case 0x0002: return 7;
+		case 0x0003:
+		case 0x0103: return 8;
+	}
+}
+
+unsigned int CalcBannerSize(unsigned short version)
+{
+	switch (version)
+	{
+		default:     version = 1; /* fallthrough */
+		case 0x0001:
+		case 0x0002:
+		case 0x0003: return 0x840 + 0x100 * (version - 1);
+		case 0x0103: return 0x23C0;
+	}
+};
+
 void BannerPutTitle(const char *text, Banner &banner)
 {
 	// convert initial title

--- a/source/banner.h
+++ b/source/banner.h
@@ -1,3 +1,5 @@
+#define BANNER_TITLE_LENGTH 128
+
 #pragma pack(1)
 
 struct Banner
@@ -7,12 +9,28 @@ struct Banner
 	unsigned char reserved[28];
 	unsigned char tile_data[4][4][8][4];
 	unsigned_short palette[16];
-	unsigned_short title[6][128];		// max. 3 lines. seperated by linefeed character
+	unsigned_short title[16][BANNER_TITLE_LENGTH];		// max. 3 lines. seperated by linefeed character
+
+	unsigned char anim_tile_data[8][4][4][8][4];
+	unsigned char anim_tile_palette[8][16];
+	unsigned_short anim_sequence[64];
 };
 
 #pragma pack()
 
 extern const char *bannerLanguages[];
+
+static inline int GetBannerLanguageCount(unsigned short version)
+{
+	switch (version)
+	{
+		default:
+		case 0x0001: return 6;
+		case 0x0002: return 7;
+		case 0x0003:
+		case 0x0103: return 8;
+	}
+}
 
 static inline unsigned int CalcBannerSize(unsigned short version)
 {
@@ -26,7 +44,6 @@ static inline unsigned int CalcBannerSize(unsigned short version)
 	}
 };
 
-int InsertTitleString(char *String, FILE *file);
 unsigned short CalcBannerCRC(Banner &banner);
 void IconFromBMP();
 void IconFromGRF();

--- a/source/banner.h
+++ b/source/banner.h
@@ -19,30 +19,8 @@ struct Banner
 
 extern const char *bannerLanguages[];
 
-static inline int GetBannerLanguageCount(unsigned short version)
-{
-	switch (version)
-	{
-		default:
-		case 0x0001: return 6;
-		case 0x0002: return 7;
-		case 0x0003:
-		case 0x0103: return 8;
-	}
-}
-
-static inline unsigned int CalcBannerSize(unsigned short version)
-{
-	switch (version)
-	{
-		default:     version = 1; /* fallthrough */
-		case 0x0001:
-		case 0x0002:
-		case 0x0003: return 0x840 + 0x100 * (version - 1);
-		case 0x0103: return 0x23C0;
-	}
-};
-
+int GetBannerLanguageCount(unsigned short version);
+unsigned int CalcBannerSize(unsigned short version);
 unsigned short GetBannerMinVersionForCRCSlot(unsigned short slot);
 unsigned short CalcBannerCRC(Banner &banner, unsigned short slot);
 void IconFromBMP();

--- a/source/banner.h
+++ b/source/banner.h
@@ -5,8 +5,7 @@
 struct Banner
 {
 	unsigned_short version;
-	unsigned_short crc;
-	unsigned char reserved[28];
+	unsigned_short crc[15];
 	unsigned char tile_data[4][4][8][4];
 	unsigned_short palette[16];
 	unsigned_short title[16][BANNER_TITLE_LENGTH];		// max. 3 lines. seperated by linefeed character
@@ -44,6 +43,7 @@ static inline unsigned int CalcBannerSize(unsigned short version)
 	}
 };
 
-unsigned short CalcBannerCRC(Banner &banner);
+unsigned short GetBannerMinVersionForCRCSlot(unsigned short slot);
+unsigned short CalcBannerCRC(Banner &banner, unsigned short slot);
 void IconFromBMP();
 void IconFromGRF();

--- a/source/header.cpp
+++ b/source/header.cpp
@@ -122,6 +122,8 @@ void FixHeaderCRC(char *ndsfilename)
  */
 void ShowHeaderInfo(Header &header, int romType, unsigned int length = 0x200)
 {
+	bool isTwl = header.unitcode & 0x02;
+
 	printf("0x00\t%-25s\t", "Game title");
 
 	for (unsigned int i=0; i<sizeof(header.title); i++)
@@ -160,7 +162,8 @@ void ShowHeaderInfo(Header &header, int romType, unsigned int length = 0x200)
 	printf("0x13\t%-25s\t0x%02X\n", "Device type", header.devicetype);
 	printf("0x14\t%-25s\t0x%02X (%d Mbit)\n", "Device capacity", header.devicecap, 1<<header.devicecap);
 	printf("0x15\t%-25s\t", "reserved 1"); for (unsigned int i=0; i<sizeof(header.reserved1); i++) printf("%02X", header.reserved1[i]); printf("\n");
-	printf("0x1E\t%-25s\t0x%02X\n", "ROM version", header.romversion);
+	if(isTwl) printf("0x1C\t%-25s\t0x%02X\n", "TWL flags", header.dsi_flags);
+	printf("0x1D\t%-25s\t0x%02X\n", isTwl ? "?" : "Region", header.nds_region);
 	printf("0x1F\t%-25s\t0x%02X\n", "reserved 2", header.reserved2);
 	printf("0x20\t%-25s\t0x%X\n", "ARM9 ROM offset", (int)header.arm9_rom_offset);
 	printf("0x24\t%-25s\t0x%X\n", "ARM9 entry address", (int)header.arm9_entry_address);

--- a/source/header.cpp
+++ b/source/header.cpp
@@ -551,9 +551,18 @@ void ShowInfo(char *ndsfilename)
 		fseek(fNDS, header.banner_offset, SEEK_SET);
 		if (fread(&banner, 1, sizeof(banner), fNDS))
 		{
-			unsigned short banner_crc = CalcBannerCRC(banner);
 			printf("\n");
-			printf("Banner CRC:                     \t0x%04X (%s)\n", (int)banner.crc, (banner_crc == banner.crc) ? "OK" : "INVALID");
+			for (int slot = 0; slot < 4; slot++)
+			{
+				unsigned short min_version = GetBannerMinVersionForCRCSlot(slot);
+				unsigned short banner_crc = CalcBannerCRC(banner, slot);
+				printf("Banner CRC %d:                   \t0x%04X", slot, (int)banner.crc[slot]);
+				if (banner.version >= min_version)
+				{
+					printf(" (%s)", (banner_crc == banner.crc[slot]) ? "OK" : "INVALID");
+				}
+				printf("\n");
+			}
 
 			for (int language=0; language<GetBannerLanguageCount(banner.version); language++)
 			{

--- a/source/utf16.cpp
+++ b/source/utf16.cpp
@@ -1,0 +1,40 @@
+#include <cstring>
+#include <iconv.h>
+#include <locale.h>
+#include "utf16.h"
+
+static bool iconv_utf16_initialized = false;
+static iconv_t iconv_utf16_from_system;
+static iconv_t iconv_utf16_to_system;
+
+static size_t utf16_wstrlen(unsigned_short *in) {
+	int i = 0;
+	while (in[i] != 0) i++;
+	return i;
+}
+
+static void utf16_iconv_init(void) {
+	if (iconv_utf16_initialized) {
+		return;
+	}
+
+	setlocale(LC_ALL, "");
+	iconv_utf16_to_system = iconv_open("", "UTF-16LE");
+	iconv_utf16_from_system = iconv_open("UTF-16LE", "");
+
+	iconv_utf16_initialized = true;
+}
+
+bool utf16_convert_from_system(const char *in, size_t in_len, unsigned_short *out, size_t out_len) {
+	utf16_iconv_init();
+	if (in_len == 0) in_len = strlen(in) + 1;
+
+	return iconv(iconv_utf16_from_system, (char**)&in, &in_len, (char**)&out, &out_len) >= 0;
+}
+
+bool utf16_convert_to_system(unsigned_short *in, size_t in_len, char *out, size_t out_len) {
+	utf16_iconv_init();
+	if (in_len == 0) in_len = (utf16_wstrlen(in) + 1) * 2;
+
+	return iconv(iconv_utf16_to_system, (char**)&in, &in_len, (char**)&out, &out_len) >= 0;
+}

--- a/source/utf16.cpp
+++ b/source/utf16.cpp
@@ -29,12 +29,12 @@ bool utf16_convert_from_system(const char *in, size_t in_len, unsigned_short *ou
 	utf16_iconv_init();
 	if (in_len == 0) in_len = strlen(in) + 1;
 
-	return iconv(iconv_utf16_from_system, (char**)&in, &in_len, (char**)&out, &out_len) >= 0;
+	return iconv(iconv_utf16_from_system, (char**)&in, &in_len, (char**)&out, &out_len) != (size_t) -1;
 }
 
 bool utf16_convert_to_system(unsigned_short *in, size_t in_len, char *out, size_t out_len) {
 	utf16_iconv_init();
 	if (in_len == 0) in_len = (utf16_wstrlen(in) + 1) * 2;
 
-	return iconv(iconv_utf16_to_system, (char**)&in, &in_len, (char**)&out, &out_len) >= 0;
+	return iconv(iconv_utf16_to_system, (char**)&in, &in_len, (char**)&out, &out_len) != (size_t) -1;
 }

--- a/source/utf16.h
+++ b/source/utf16.h
@@ -1,0 +1,19 @@
+#include "little.h"
+
+/**
+ * @brief Convert from the system locale to UTF-16.
+ * @param in Input string.
+ * @param out Output buffer.
+ * @param out_len Output buffer length, in bytes.
+ * @return True if successful.
+ */
+bool utf16_convert_from_system(const char *in, size_t in_len, unsigned_short *out, size_t out_len);
+
+/**
+ * @brief Convert from UTF-16 to the system locale.
+ * @param in Input buffer.
+ * @param out Output string.
+ * @param out_len Output string length, in bytes.
+ * @return True if successful.
+ */
+bool utf16_convert_to_system(unsigned_short *in, size_t in_len, char *out, size_t out_len);


### PR DESCRIPTION
Fully resolves #1 .

This also fixes:

- Displaying other banner text languages than English in the `info` mode.
- Displaying and calculating all banner CRCs for newer banners.
- Displaying the values of fields 0x1C and 0x1D in the `info` mode.