### PR TITLE
Replace PACKAGE_VERSION & __DATE__ with release tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,8 @@ SDK_VERSION	?= $(shell git describe --tags --exact-match --dirty 2>/dev/null)
 
 # Fallback to commit hash
 ifeq ($(SDK_VERSION),)
-    VERSION_ID	:= "commit $(shell git describe --always --dirty 2>/dev/null)"
+    # --exclude to prevent any older tags from being displayed
+    VERSION_ID	:= "commit $(shell git describe --always --dirty --exclude '*' 2>/dev/null)"
 else
     VERSION_ID	:= "BlocksDS $(SDK_VERSION)"
 endif

--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,20 @@
 SOURCEDIRS	:= source
 INCLUDEDIRS	:= source
 
+# Try to find the SDK version if it wasn't already provided e.g. by the parent Makefile
+SDK_VERSION	?= $(shell git describe --tags --exact-match --dirty 2>/dev/null)
+
+# Fallback to commit hash
+ifeq ($(SDK_VERSION),)
+    VERSION_ID	:= "commit $(shell git describe --always --dirty 2>/dev/null)"
+else
+    VERSION_ID	:= "BlocksDS $(SDK_VERSION)"
+endif
+
 # Defines passed to all files
 # ---------------------------
 
-DEFINES		:= -DPACKAGE_VERSION=\"2.3.0\"
+DEFINES		:= -DVERSION_ID=\"$(VERSION_ID)\"
 
 # Libraries
 # ---------

--- a/source/compile_date.c
+++ b/source/compile_date.c
@@ -1,3 +1,0 @@
-// SPDX-FileNotice: Modified from the original version by the BlocksDS project, starting from 2023.
-
-const char CompileDate[] = __DATE__;

--- a/source/ndstool.cpp
+++ b/source/ndstool.cpp
@@ -60,7 +60,7 @@ unsigned int appFlags = 0x01;
 
 void Title()
 {
-	printf("Nintendo DS rom tool " PACKAGE_VERSION " - %s\nby Rafael Vuijk, Dave Murphy, Alexei Karpenko\n",CompileDate);
+	printf("Nintendo DS rom tool (" VERSION_ID ")\nby Rafael Vuijk, Dave Murphy, Alexei Karpenko\n");
 }
 
 // Argument information

--- a/source/ndstool.h
+++ b/source/ndstool.h
@@ -74,5 +74,3 @@ extern char *gamecode;
 extern int latency1;
 extern int latency2;
 extern unsigned int romversion;
-
-extern const char CompileDate[];


### PR DESCRIPTION
Relevant: https://github.com/blocksds/sdk/issues/196

For some reason, `git describe` seems to return the oldest of all the lightweight tags for any given commit on my machine, so commit `8113974d7f975e349c0e8f7d11b5c1e16e77a496` appears as `v1.4.0-blocks` instead of `v1.5.0-blocks` because they are the same commit. This could be fixed by using git's annotated tags, or partially fixed by having `SDK_VERSION` additionally defined in the top-level SDK Makefile since the SDK always has commits between versions.
